### PR TITLE
Finance text classification benchmarks

### DIFF
--- a/glue.py
+++ b/glue.py
@@ -62,7 +62,7 @@ TASK_NAME_TO_CLASS = {
     "swag": misc_jobs_module.SWAGJob,
     "eurlex": misc_jobs_module.EurlexJob,
     "fpb": misc_jobs_module.FPBJob,
-    "fiqa": misc_jobs_module.FiQaJob,
+    "fiqa": misc_jobs_module.FiQAJob,
     "headline": misc_jobs_module.HeadlineJob,
 }
 

--- a/glue.py
+++ b/glue.py
@@ -62,6 +62,7 @@ TASK_NAME_TO_CLASS = {
     "swag": misc_jobs_module.SWAGJob,
     "eurlex": misc_jobs_module.EurlexJob,
     "fpb": misc_jobs_module.FPBJob,
+    "fiqa": misc_jobs_module.FiQaJob,
 }
 
 GLUE_TASKS = {"mnli", "rte", "mrpc", "qnli", "qqp", "sst2", "stsb", "cola"}
@@ -469,7 +470,7 @@ def train(config: om.DictConfig) -> None:
         # superglue:
         *{"boolq", "cb", "multirc", "wic"},
         # misc:
-        *{"swag", "eurlex", "fpb"},
+        *{"swag", "eurlex", "fpb", "fiqa"},
     }
     round_1_job_configs = create_job_configs(
         config, round_1_task_names, local_pretrain_checkpoint_path

--- a/glue.py
+++ b/glue.py
@@ -63,6 +63,7 @@ TASK_NAME_TO_CLASS = {
     "eurlex": misc_jobs_module.EurlexJob,
     "fpb": misc_jobs_module.FPBJob,
     "fiqa": misc_jobs_module.FiQaJob,
+    "headline": misc_jobs_module.HeadlineJob,
 }
 
 GLUE_TASKS = {"mnli", "rte", "mrpc", "qnli", "qqp", "sst2", "stsb", "cola"}
@@ -470,7 +471,7 @@ def train(config: om.DictConfig) -> None:
         # superglue:
         *{"boolq", "cb", "multirc", "wic"},
         # misc:
-        *{"swag", "eurlex", "fpb", "fiqa"},
+        *{"swag", "eurlex", "fpb", "fiqa", "headline"},
     }
     round_1_job_configs = create_job_configs(
         config, round_1_task_names, local_pretrain_checkpoint_path

--- a/glue.py
+++ b/glue.py
@@ -61,6 +61,7 @@ TASK_NAME_TO_CLASS = {
     "wic": superglue_jobs_module.WiCJob,
     "swag": misc_jobs_module.SWAGJob,
     "eurlex": misc_jobs_module.EurlexJob,
+    "fpb": misc_jobs_module.FPBJob,
 }
 
 GLUE_TASKS = {"mnli", "rte", "mrpc", "qnli", "qqp", "sst2", "stsb", "cola"}
@@ -468,7 +469,7 @@ def train(config: om.DictConfig) -> None:
         # superglue:
         *{"boolq", "cb", "multirc", "wic"},
         # misc:
-        *{"swag", "eurlex"},
+        *{"swag", "eurlex", "fpb"},
     }
     round_1_job_configs = create_job_configs(
         config, round_1_task_names, local_pretrain_checkpoint_path

--- a/src/evals/data.py
+++ b/src/evals/data.py
@@ -173,3 +173,10 @@ def create_fiqa_dataset(**kwargs):
         dataset_name="TheFinAI/fiqa-sentiment-classification",
         task_column_names={"default": ("sentence",)},
     )
+
+def create_headline_dataset(**kwargs):
+    return create_eval_dataset(
+        **kwargs,
+        dataset_name="SaguaroCapital/sentiment-analysis-in-commodity-market-gold",
+        task_column_names={"default": ("News",) },
+    )

--- a/src/evals/data.py
+++ b/src/evals/data.py
@@ -156,3 +156,13 @@ def create_eurlex_dataset(**kwargs):
         dataset_subset="eurlex",
         task_column_names={"coastalcph/lex_glue": ("text",)},
     )
+
+def create_fpb_dataset(**kwargs):
+    return create_eval_dataset(
+        **kwargs,
+        dataset_name="takala/financial_phrasebank",
+        task_column_names={"sentences_allagree": ("sentence",), 
+                           "sentences_75agree": ("sentence",), 
+                           "sentences_66agree": ("sentence",), 
+                           "sentences_50agree": ("sentence",)},
+    )

--- a/src/evals/data.py
+++ b/src/evals/data.py
@@ -166,3 +166,10 @@ def create_fpb_dataset(**kwargs):
                            "sentences_66agree": ("sentence",), 
                            "sentences_50agree": ("sentence",)},
     )
+
+def create_fiqa_dataset(**kwargs):
+    return create_eval_dataset(
+        **kwargs,
+        dataset_name="TheFinAI/fiqa-sentiment-classification",
+        task_column_names={"default": ("sentence",)},
+    )

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -6,6 +6,7 @@ import os
 import sys
 from itertools import chain
 from typing import List, Optional
+from datasets import concatenate_datasets
 
 # Add glue folder root to path to allow us to use relative imports regardless of what directory the script is run from
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
@@ -16,7 +17,7 @@ from composer.core.evaluator import Evaluator
 from composer.loggers import LoggerDestination
 from composer.optim import ComposerScheduler, DecoupledAdamW
 from torchmetrics.classification import MulticlassF1Score, MultilabelF1Score
-from src.evals.data import create_swag_dataset, create_eurlex_dataset, create_fpb_dataset
+from src.evals.data import create_swag_dataset, create_eurlex_dataset, create_fpb_dataset, create_fiqa_dataset
 from src.evals.finetuning_jobs import (
     build_dataloader,
     multiple_choice_collate_fn,
@@ -353,3 +354,109 @@ class FPBJob(ClassificationJob):
         )
 
         self.evaluators = [fpb_evaluator] 
+
+class FiQaWeightedMulticlassF1Score(MulticlassF1Score):
+    def __init__(self):
+        super().__init__(num_classes=3, average='weighted')
+
+class FiQaJob(ClassificationJob):
+    """FiQa task 1 sentiment classification."""
+    custom_eval_metrics = [FiQaWeightedMulticlassF1Score]
+    num_labels = 1
+
+    def __init__(
+        self,
+        model: ComposerModel,
+        tokenizer_name: str,
+        job_name: Optional[str] = None,
+        seed: int = 42,
+        eval_interval: str = "1600ba",
+        scheduler: Optional[ComposerScheduler] = None,
+        max_sequence_length: Optional[int] = 512,
+        max_duration: Optional[str] = "3ep",
+        batch_size: Optional[int] = 16,
+        load_path: Optional[str] = None,
+        save_folder: Optional[str] = None,
+        loggers: Optional[List[LoggerDestination]] = None,
+        callbacks: Optional[List[Callback]] = None,
+        precision: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            model=model,
+            tokenizer_name=tokenizer_name,
+            job_name=job_name,
+            seed=seed,
+            task_name="default",
+            eval_interval=eval_interval,
+            scheduler=scheduler,
+            max_sequence_length=max_sequence_length,
+            max_duration=max_duration,
+            batch_size=batch_size,
+            load_path=load_path,
+            save_folder=save_folder,
+            loggers=loggers,
+            callbacks=callbacks,
+            precision=precision,
+            **kwargs,
+        )
+
+        self.optimizer = DecoupledAdamW(
+            self.model.parameters(),
+            lr=5.0e-5,
+            betas=(0.9, 0.98),
+            eps=1.0e-06,
+            weight_decay=1.0e-06,
+        )
+
+        def tokenize_fn_factory(tokenizer, max_seq_length):
+            def tokenize_fn(inp):
+                first_sentences = inp["sentence"]
+                tokenized_examples = tokenizer(
+                    first_sentences,
+                    padding="max_length",
+                    max_length=max_seq_length,
+                    truncation=True,
+                )
+                return tokenized_examples
+            return tokenize_fn
+
+        dataset_kwargs = {
+            "task": self.task_name,
+            "tokenizer_name": self.tokenizer_name,
+            "max_seq_length": self.max_sequence_length,
+            "tokenize_fn_factory": tokenize_fn_factory,
+        }
+
+        dataloader_kwargs = {
+            "batch_size": self.batch_size,
+            "num_workers": 0,
+            "drop_last": False,
+        }
+
+        fiqa_train_dataset = create_fiqa_dataset(split="train", **dataset_kwargs)
+        fiqa_eval_dataset = create_fiqa_dataset(split="test", **dataset_kwargs)
+        fiqa_val_dataset = create_fiqa_dataset(split="valid", **dataset_kwargs)
+        combined_dataset = concatenate_datasets([fiqa_train_dataset, fiqa_eval_dataset, fiqa_val_dataset])
+        split_datasets = combined_dataset.train_test_split(test_size=1-0.8)
+        fiqa_train_dataset = split_datasets['train']
+        fiqa_eval_dataset = split_datasets['test']
+
+        def convert_scores_to_labels(example):
+            if float(example['score']) < -0.1:
+                example['labels'] = 0.0
+            elif float(example['score']) >= 0.1:
+                example['labels'] = 2.0
+            else:
+                example['labels'] = 1.0
+            return example
+        fiqa_train_dataset = fiqa_train_dataset.map(convert_scores_to_labels, remove_columns=["_id", "target", "aspect", "score", "type"])
+        fiqa_eval_dataset = fiqa_eval_dataset.map(convert_scores_to_labels, remove_columns=["_id", "target", "aspect", "score", "type"])
+        self.train_dataloader = build_dataloader(fiqa_train_dataset, **dataloader_kwargs)
+
+        fiqa_evaluator = Evaluator(
+            label="fiqa_evaluator",
+            dataloader=build_dataloader(fiqa_eval_dataset, **dataloader_kwargs),
+            metric_names=["FiQaWeightedMulticlassF1Score"],
+        )
+        self.evaluators = [fiqa_evaluator]

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -17,7 +17,7 @@ from composer.core.evaluator import Evaluator
 from composer.loggers import LoggerDestination
 from composer.optim import ComposerScheduler, DecoupledAdamW
 from torchmetrics.classification import MulticlassF1Score, MultilabelF1Score
-from src.evals.data import create_swag_dataset, create_eurlex_dataset, create_fpb_dataset, create_fiqa_dataset
+from src.evals.data import create_swag_dataset, create_eurlex_dataset, create_fpb_dataset, create_fiqa_dataset, create_headline_dataset
 from src.evals.finetuning_jobs import (
     build_dataloader,
     multiple_choice_collate_fn,
@@ -460,3 +460,107 @@ class FiQaJob(ClassificationJob):
             metric_names=["FiQaWeightedMulticlassF1Score"],
         )
         self.evaluators = [fiqa_evaluator]
+
+class HeadlineJob(ClassificationJob):
+    """Gold Headlines sentiment classification."""
+    custom_eval_metrics = [FPBMulticlassF1Score]
+    num_labels = 1
+
+    def __init__(
+        self,
+        model: ComposerModel,
+        tokenizer_name: str,
+        job_name: Optional[str] = None,
+        seed: int = 42,
+        eval_interval: str = "1600ba",
+        scheduler: Optional[ComposerScheduler] = None,
+        max_sequence_length: Optional[int] = 512,
+        max_duration: Optional[str] = "3ep",
+        batch_size: Optional[int] = 32,
+        load_path: Optional[str] = None,
+        save_folder: Optional[str] = None,
+        loggers: Optional[List[LoggerDestination]] = None,
+        callbacks: Optional[List[Callback]] = None,
+        precision: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            model=model,
+            tokenizer_name=tokenizer_name,
+            job_name=job_name,
+            seed=seed,
+            task_name="default",
+            eval_interval=eval_interval,
+            scheduler=scheduler,
+            max_sequence_length=max_sequence_length,
+            max_duration=max_duration,
+            batch_size=batch_size,
+            load_path=load_path,
+            save_folder=save_folder,
+            loggers=loggers,
+            callbacks=callbacks,
+            precision=precision,
+            **kwargs,
+        )
+
+        self.optimizer = DecoupledAdamW(
+            self.model.parameters(),
+            lr=5.0e-5,
+            betas=(0.9, 0.98),
+            eps=1.0e-06,
+            weight_decay=1.0e-06,
+        )
+
+
+        def tokenize_fn_factory(tokenizer, max_seq_length):
+            def tokenize_fn(inp):
+                first_sentences = inp["News"]
+
+                tokenized_examples = tokenizer(
+                    first_sentences,
+                    padding="max_length",
+                    max_length=max_seq_length,
+                    truncation=True,
+                )
+
+                return tokenized_examples
+            return tokenize_fn
+
+        dataset_kwargs = {
+            "task": self.task_name,
+            "tokenizer_name": self.tokenizer_name,
+            "max_seq_length": self.max_sequence_length,
+            "tokenize_fn_factory": tokenize_fn_factory,
+        }
+
+        dataloader_kwargs = {
+            "batch_size": self.batch_size,
+            "num_workers": 0,
+            "drop_last": False,
+        }
+        
+        headline_train_dataset = create_headline_dataset(split="train", **dataset_kwargs)
+        headline_eval_dataset = create_headline_dataset(split="test", **dataset_kwargs)
+
+
+        def convert_labels_to_float(example):
+            if example['Price Sentiment'] == 'negative':
+                example['labels'] = 0.0
+            elif example['Price Sentiment'] == 'positive':
+                example['labels'] = 2.0
+            else:
+                example['labels'] = 1.0
+            return example
+        headline_train_dataset = headline_train_dataset.map(convert_labels_to_float, remove_columns=["Dates", "URL", "Price Direction Up", "Price Direction Constant", "Price Direction Down", "Asset Comparision", "Past Information", "Future Information", "Price Sentiment"])
+        headline_eval_dataset = headline_eval_dataset.map(convert_labels_to_float, remove_columns=["Dates", "URL", "Price Direction Up", "Price Direction Constant", "Price Direction Down", "Asset Comparision", "Past Information", "Future Information", "Price Sentiment"])
+        
+        self.train_dataloader = build_dataloader(headline_train_dataset, **dataloader_kwargs)
+
+
+        headline_evaluator = Evaluator(
+            label="headline_evaluator",
+            dataloader=build_dataloader(headline_eval_dataset, **dataloader_kwargs),
+            metric_names=["FPBMulticlassF1Score"],
+        )
+
+        self.evaluators = [headline_evaluator]

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -355,13 +355,13 @@ class FPBJob(ClassificationJob):
 
         self.evaluators = [fpb_evaluator] 
 
-class FiQaWeightedMulticlassF1Score(MulticlassF1Score):
+class FiQAWeightedMulticlassF1Score(MulticlassF1Score):
     def __init__(self):
         super().__init__(num_classes=3, average='weighted')
 
-class FiQaJob(ClassificationJob):
-    """FiQa task 1 sentiment classification."""
-    custom_eval_metrics = [FiQaWeightedMulticlassF1Score]
+class FiQAJob(ClassificationJob):
+    """FiQA task 1 sentiment classification."""
+    custom_eval_metrics = [FiQAWeightedMulticlassF1Score]
     num_labels = 1
 
     def __init__(
@@ -457,7 +457,7 @@ class FiQaJob(ClassificationJob):
         fiqa_evaluator = Evaluator(
             label="fiqa_evaluator",
             dataloader=build_dataloader(fiqa_eval_dataset, **dataloader_kwargs),
-            metric_names=["FiQaWeightedMulticlassF1Score"],
+            metric_names=["FiQAWeightedMulticlassF1Score"],
         )
         self.evaluators = [fiqa_evaluator]
 

--- a/src/evals/misc_jobs.py
+++ b/src/evals/misc_jobs.py
@@ -252,13 +252,13 @@ class EurlexJob(ClassificationJob):
 
         self.evaluators = [eurlex_evaluator]
 
-class FPBMulticlassF1Score(MulticlassF1Score):
+class FPBWeightedMulticlassF1Score(MulticlassF1Score):
     def __init__(self):
-        super().__init__(num_classes=3)
+        super().__init__(num_classes=3, average='weighted')
 
 class FPBJob(ClassificationJob):
     """Financial Phrasebank classification."""
-    custom_eval_metrics = [FPBMulticlassF1Score]
+    custom_eval_metrics = [FPBWeightedMulticlassF1Score]
     num_labels = 1
 
     def __init__(
@@ -350,7 +350,7 @@ class FPBJob(ClassificationJob):
         fpb_evaluator = Evaluator(
             label="fpb_evaluator",
             dataloader=build_dataloader(fpb_eval_dataset, **dataloader_kwargs),
-            metric_names=["FPBMulticlassF1Score"],
+            metric_names=["FPBWeightedMulticlassF1Score"],
         )
 
         self.evaluators = [fpb_evaluator] 
@@ -461,9 +461,13 @@ class FiQaJob(ClassificationJob):
         )
         self.evaluators = [fiqa_evaluator]
 
+class HeadlineWeightedMulticlassF1Score(MulticlassF1Score):
+    def __init__(self):
+        super().__init__(num_classes=3, average='weighted')
+
 class HeadlineJob(ClassificationJob):
     """Gold Headlines sentiment classification."""
-    custom_eval_metrics = [FPBMulticlassF1Score]
+    custom_eval_metrics = [HeadlineWeightedMulticlassF1Score]
     num_labels = 1
 
     def __init__(
@@ -560,7 +564,7 @@ class HeadlineJob(ClassificationJob):
         headline_evaluator = Evaluator(
             label="headline_evaluator",
             dataloader=build_dataloader(headline_eval_dataset, **dataloader_kwargs),
-            metric_names=["FPBMulticlassF1Score"],
+            metric_names=["HeadlineWeightedMulticlassF1Score"],
         )
 
         self.evaluators = [headline_evaluator]

--- a/yamls/baselines/bert-base-uncased-finance.yaml
+++ b/yamls/baselines/bert-base-uncased-finance.yaml
@@ -43,3 +43,7 @@ tasks:
     seeds: [19, 8364, 717, 10536]
     trainer_kwargs:
       save_num_checkpoints_to_keep: 0
+  fiqa:
+    seeds: [19, 8364, 717, 10536]
+    trainer_kwargs:
+      save_num_checkpoints_to_keep: 0

--- a/yamls/baselines/bert-base-uncased-finance.yaml
+++ b/yamls/baselines/bert-base-uncased-finance.yaml
@@ -1,0 +1,45 @@
+# Whether to run the various GLUE jobs serially or in parallel (use parallel=True to take advantage of multiple GPUs)
+parallel: true
+
+# Basic run configuration, additional details will be added to this name for each GLUE task, and each random seed
+base_run_name: bert-base-uncased-glue-finetuning
+default_seed: 19
+precision: amp_bf16
+
+# Tokenizer for dataset creation
+tokenizer_name: bert-base-uncased
+
+# Base model config
+model:
+  name: hf_bert
+  use_pretrained: true
+  pretrained_model_name: ${tokenizer_name}
+  tokenizer_name: ${tokenizer_name}
+
+# Saving
+save_finetune_checkpoint_prefix: ./bert-finetune-checkpoints
+save_finetune_checkpoint_folder: ${save_finetune_checkpoint_prefix}/${base_run_name}
+
+# (Optional) W&B logging
+# loggers:
+  # wandb:
+    # project: # Fill this in if using W&B
+    # entity: # Fill this in if using W&B
+
+# Callbacks
+callbacks:
+  lr_monitor: {}
+  speed_monitor: {}
+
+# Scheduler
+scheduler:
+  name: linear_decay_with_warmup
+  t_warmup: 0.06dur
+  alpha_f: 0.0
+
+# Task configuration
+tasks:
+  fpb:
+    seeds: [19, 8364, 717, 10536]
+    trainer_kwargs:
+      save_num_checkpoints_to_keep: 0

--- a/yamls/baselines/bert-base-uncased-finance.yaml
+++ b/yamls/baselines/bert-base-uncased-finance.yaml
@@ -47,3 +47,7 @@ tasks:
     seeds: [19, 8364, 717, 10536]
     trainer_kwargs:
       save_num_checkpoints_to_keep: 0
+  headline:
+    seeds: [19, 8364, 717, 10536]
+    trainer_kwargs:
+      save_num_checkpoints_to_keep: 0


### PR DESCRIPTION
**Changes**

Add finance text classification benchmarks to the evals. We followed their splits/thresholds as closely as possible. The benchmarks have been added to `yamls/baselines/bert-base-uncased-finance.yaml`
- FPB
- FiQA
- Headline


**Discussions**

N/A

**Tests**


- [ ] Is the new feature tested? (Not always necessary for all changes -- just adding to the checklist to keep track)
- [x] Have you ran all the tests?
- [x] Do the tests all pass?
- [ ] If not, have you included an explanation of which tests this PR breaks and/or why (below this checklist)



| Task     | HF Bert | Flex Bert |
|----------|---------|-----------|
| FPB      | 58.03   | 27.55     | 
| FiQA     | 49.65   | 23.97     |
| Headline | 81.97   | 51.59     | 
